### PR TITLE
Downscale the extracted frames from video (n3d)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ poses/__pycache__/*.pyc
 
 
 .vscode/
+.idea/
 
 tmp/*
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can train our model by running the following command: </br>
 
 ```
 conda activate feature_splatting
-python train.py --quiet --eval --config config/<dataset>_<lite|full>/<scene>.json --model_path <path to save model> --source_path <location>/<scene>/colmap_0
+python train.py --quiet --eval --config configs/<dataset>_<lite|full>/<scene>.json --model_path <path to save model> --source_path <location>/<scene>/colmap_0
 ```
 In the argument to ```--config```, ```<dataset>``` can be ```n3d``` (for Neural 3D Dataset) or ```techni``` (for Technicolor Dataset), and you can choose between ```full``` model or ```lite``` model. </br>
 You need 24GB GPU memory to train on the Neural 3D Dataset. </br>
@@ -208,12 +208,12 @@ Please refer to the .json config files for more options.
 - Test model on Neural 3D Dataset
 
 ```
-python test.py --quiet --eval --skip_train --valloader colmapvalid --configpath config/n3d_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scene>/colmap_0
+python test.py --quiet --eval --skip_train --valloader colmapvalid --configpath configs/n3d_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scene>/colmap_0
 ```
 
 - Test model on Technicolor Dataset
 ```
-python test.py --quiet --eval --skip_train --valloader technicolorvalid --configpath config/techni_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scenename>/colmap_0
+python test.py --quiet --eval --skip_train --valloader technicolorvalid --configpath configs/techni_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scenename>/colmap_0
 ```
 - Test on Google Immersive Dataset with distortion camera model 
 
@@ -223,7 +223,7 @@ pip install thirdparty/gaussian_splatting/submodules/forward_full
 ```
 
 ```
-PYTHONDONTWRITEBYTECODE=1 CUDA_VISIBLE_DEVICES=0 python test.py --quiet --eval --skip_train --valloader immersivevalidss --configpath config/im_distort_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scenename>/colmap_0
+PYTHONDONTWRITEBYTECODE=1 CUDA_VISIBLE_DEVICES=0 python test.py --quiet --eval --skip_train --valloader immersivevalidss --configpath configs/im_distort_<lite|full>/<scene>.json --model_path <path to model> --source_path <location>/<scenename>/colmap_0
 ```
 
 

--- a/configs/n3d_lite/flame_steak.json
+++ b/configs/n3d_lite/flame_steak.json
@@ -4,6 +4,6 @@
   "scaling_lr": 0.0015,
   "preprocesspoints": 3,
   "test_iteration": 25000,
-  "duration": 50,
+  "duration": 25,
   "rdpip": "train_ours_lite"
 }

--- a/configs/n3d_lite/flame_steak.json
+++ b/configs/n3d_lite/flame_steak.json
@@ -4,6 +4,6 @@
   "scaling_lr": 0.0015,
   "preprocesspoints": 3,
   "test_iteration": 25000,
-  "duration": 25,
+  "duration": 50,
   "rdpip": "train_ours_lite"
 }

--- a/script/pre_n3d.py
+++ b/script/pre_n3d.py
@@ -204,7 +204,7 @@ if __name__ == "__main__" :
     print("start extracting 300 frames from videos")
     videoslist = glob.glob(videopath + "*.mp4")
     for v in tqdm.tqdm(videoslist):
-        extractframes(v, startframe, endframe, downscale)
+        extractframes(v, downscale=downscale)
 
     
 

--- a/script/pre_n3d.py
+++ b/script/pre_n3d.py
@@ -20,7 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os 
+import os
+from pathlib import Path
+
 import cv2 
 import glob 
 import tqdm 
@@ -37,32 +39,31 @@ from thirdparty.gaussian_splatting.helper3dg import getcolmapsinglen3d
 
 
 
-def extractframes(videopath):
-    cam = cv2.VideoCapture(videopath)
-    ctr = 0
-    sucess = True
-    for i in range(300):
-        if os.path.exists(os.path.join(videopath.replace(".mp4", ""), str(i) + ".png")):
-            ctr += 1
-    if ctr == 300 or ctr == 150: # 150 for 04_truck 
-        print("already extracted all the frames, skip extracting")
+def extractframes(videopath_str, startframe=0, endframe=300, downscale=1):
+    videopath = Path(videopath_str)
+    output_dir = videopath.with_suffix('')
+    if all((output_dir / f"{i}.png").exists() for i in range(startframe, endframe)):
+        print(f"Already extracted all the frames in {output_dir}")
         return
-    ctr = 0
-    while ctr < 300:
-        try:
-            _, frame = cam.read()
 
-            savepath = os.path.join(videopath.replace(".mp4", ""), str(ctr) + ".png")
-            if not os.path.exists(videopath.replace(".mp4", "")) :
-                os.makedirs(videopath.replace(".mp4", ""))
+    cam = cv2.VideoCapture(str(videopath))
+    cam.set(cv2.CAP_PROP_POS_FRAMES, startframe)
 
-            cv2.imwrite(savepath, frame)
-            ctr += 1 
-        except:
-            sucess = False
-            print("error")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for i in range(startframe, endframe):
+        success, frame = cam.read()
+        if not success:
+            print(f"Error reading frame {i}")
+            break
+
+        if downscale > 1:
+            new_width, new_height = int(frame.shape[1] / downscale), int(frame.shape[0] / downscale)
+            frame = cv2.resize(frame, (new_width, new_height), interpolation=cv2.INTER_AREA)
+
+        cv2.imwrite(str(output_dir / f"{i}.png"), frame)
+
     cam.release()
-    return
 
 
 def preparecolmapdynerf(folder, offset=0):
@@ -82,7 +83,7 @@ def preparecolmapdynerf(folder, offset=0):
 
 
     
-def convertdynerftocolmapdb(path, offset=0):
+def convertdynerftocolmapdb(path, offset=0, downscale=1):
     originnumpy = os.path.join(path, "poses_bounds.npy")
     video_paths = sorted(glob.glob(os.path.join(path, 'cam*.mp4')))
     projectfolder = os.path.join(path, "colmap_" + str(offset))
@@ -122,7 +123,7 @@ def convertdynerftocolmapdb(path, offset=0):
             colmapR = m[:3, :3]
             T = m[:3, 3]
             
-            H, W, focal = poses[i, :, -1]
+            H, W, focal = poses[i, :, -1] / downscale
             
             colmapQ = rotmat2qvec(colmapR)
             # colmapRcheck = qvec2rotmat(colmapQ)
@@ -173,13 +174,16 @@ if __name__ == "__main__" :
     parser.add_argument("--videopath", default="", type=str)
     parser.add_argument("--startframe", default=0, type=int)
     parser.add_argument("--endframe", default=50, type=int)
+    parser.add_argument("--downscale", default=1, type=int)
 
     args = parser.parse_args()
     videopath = args.videopath
 
     startframe = args.startframe
     endframe = args.endframe
+    downscale = args.downscale
 
+    print(f"params: startframe={startframe} - endframe={endframe} - downscale={downscale} - videopath={videopath}")
 
     if startframe >= endframe:
         print("start frame must smaller than end frame")
@@ -200,7 +204,7 @@ if __name__ == "__main__" :
     print("start extracting 300 frames from videos")
     videoslist = glob.glob(videopath + "*.mp4")
     for v in tqdm.tqdm(videoslist):
-        extractframes(v)
+        extractframes(v, startframe, endframe, downscale)
 
     
 
@@ -213,7 +217,7 @@ if __name__ == "__main__" :
     print("start preparing colmap database input")
     # # ## step 3 prepare colmap db file 
     for offset in range(startframe, endframe):
-        convertdynerftocolmapdb(videopath, offset)
+        convertdynerftocolmapdb(videopath, offset, downscale)
 
 
     # ## step 4 run colmap, per frame, if error, reinstall opencv-headless 


### PR DESCRIPTION
Add downscale parameter to resize the frames right after their extractions in order to save RAM and hard disk (and GPU VRAM?)
Doing that allow me to run flame_steak on my laptop with RTX3060-mobile 6GB VRAM and 20GB RAM

Remind that there is also the resolution param in config.
Thus if we have --downscale 2 and config/resolution: 4 final image takes into account will be 2*4=8

`python script/pre_n3d.py --videopath flame_steak --downscale 4 --startframe 200 --endframe 225`

I also rework extractframes fn to avoid extracting useless frames (save time and hard disk)