### PR TITLE
Be able to use relative path with pre_immersive_[un]distorted.py

### DIFF
--- a/script/pre_immersive_undistorted.py
+++ b/script/pre_immersive_undistorted.py
@@ -299,7 +299,7 @@ if __name__ == "__main__" :
         extractframes(v)
 
 
-    softlinkdataset(originalpath, dstpath, srcscene, scene)
+    softlinkdataset(originalpath, dstpath)
 
     imageundistort_no_mapper(dstpath, offsetlist=[i for i in range(startframe,endframe)],focalscale=scale, fixfocal=None)
   


### PR DESCRIPTION
Calling for example `python script/pre_immersive_distorted.py --videopath ../dataset/immersive/tmp/02_Flames` lead to **broken link** as it uses **relative** path instead of absolute path.
That problem has been already reported here https://github.com/oppo-us-research/SpacetimeGaussians/issues/33#issuecomment-2031076951

As I indicated there,

> That error occurs because you use relative path (to the project dir), and because when creating a symbolic link with ln -s if the DIRECTORY is relative, it must be relative to the TARGET (not to the project/working dir)
> In short: use absolute path (or use pathlib and .resolve() in the code )

That commit fixes it using pathlib