### PR TITLE
Fix mmcv submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/mmcv"]
+	path = thirdparty/mmcv
+	url = git@github.com:open-mmlab/mmcv.git

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please first refer to [here](./script/wsl.md) to install the WSL2 system (Window
 ### Linux users :
 Clone the source code of this repo.
 ```
-git clone https://github.com/oppo-us-research/SpacetimeGaussians.git
+git clone https://github.com/oppo-us-research/SpacetimeGaussians.git --recursive
 cd SpacetimeGaussians
 ```
 

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -27,9 +27,7 @@ pip install thirdparty/gaussian_splatting/submodules/simple-knn
 # install opencv-python-headless, to work with colmap on server
 pip install opencv-python
 # Install MMCV for CUDA KNN, used for init point sampling, reduce number of points when sfm points are too many
-cd thirdparty
-git clone https://github.com/open-mmlab/mmcv.git
-cd mmcv
+cd thirdparty/mmcv # if mmcv dir is empty this is because you forgot to clone with --recursive, you can run `git submodule update --init`
 pip install -e .
 cd ../../
 

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -27,9 +27,7 @@ pip install thirdparty/gaussian_splatting/submodules/simple-knn
 # install opencv-python-headless, to work with colmap on server
 pip install opencv-python
 # Install MMCV for CUDA KNN, used for init point sampling, reduce number of points when sfm points are too many
-cd thirdparty/mmcv # if mmcv dir is empty this is because you forgot to clone with --recursive, you can run `git submodule update --init`
-pip install -e .
-cd ../../
+pip install -e thirdparty/mmcv -v # take ~30min; if mmcv dir is empty: `git submodule update --init` (or git clone with --recursive)
 
 # other packages
 pip install natsort


### PR DESCRIPTION
Hello,

The mmcv submodule does not point to any repo.
I suggest to fix it; and thus slighly simplify the setup process.

before:
![image](https://github.com/user-attachments/assets/d5edb482-2dd3-431a-bd6e-5d49a1d88709)
```
$ git submodule status
fatal: no submodule mapping found in .gitmodules for path 'thirdparty/mmcv'
```

after:
![image](https://github.com/user-attachments/assets/5d6a2e2e-42a7-4f51-a8ef-0552ebc7f0ec)
```
$ git submodule status
 3ba02dfd35c326306346bd9d35a887efc2b30fb0 thirdparty/mmcv (v2.2.0-13-g3ba02dfd)
```


(Note that when changing branch, it might be able to run `git submodule update --init` because `git clone --recursive` does not get submodule of others branchs)