### PR TITLE
update the submodule url to use https url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/mmcv"]
 	path = thirdparty/mmcv
-	url = git@github.com:open-mmlab/mmcv.git
+	url = https://github.com/open-mmlab/mmcv.git


### PR DESCRIPTION
If the user uses `git clone https://github.com/remmel/SpacetimeGaussians.git --recursive` instead of `git clone git@github.com:remmel/SpacetimeGaussians.git --recursive`, it is needed to have the submodule uses the https git url version.
Note that using `git clone https://...` can be used if the user don't have ssh git keys or don't have them registered in his github account.

Thus it will fix that message error and let an user which don't have ssh keys being able to clone the repo:
```
Cloning into 'SpacetimeGaussians'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists
```